### PR TITLE
feat: CAS function for foldering the file based on the hash sha1 + hex

### DIFF
--- a/store.go
+++ b/store.go
@@ -1,10 +1,33 @@
 package main
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"io"
 	"log"
 	"os"
+	"strings"
 )
+
+// CASPathTransformFunc takes a key string and returns a string representation of a file path
+// based on a SHA1 hash of the key. The path is constructed by splitting the hash into
+// 5-character segments and joining them with forward slashes.
+// This function is used to generate a file path for storing data in a content-addressable
+// storage (CAS) system, where the path is derived from the content of the data being stored.
+func CASPathTransformFunc(key string) string {
+	hash := sha1.Sum([]byte(key))
+	hashStr := hex.EncodeToString(hash[:])
+	blockSize := 5
+	sliceLen := len(hashStr) / blockSize
+
+	paths := make([]string, sliceLen)
+
+	for i := 0; i < sliceLen; i++ {
+		from, to := i*blockSize, (i+1)*blockSize
+		paths[i] = hashStr[from:to]
+	}
+	return strings.Join(paths, "/")
+}
 
 type PathTransformFunc func(string) string
 

--- a/store_test.go
+++ b/store_test.go
@@ -2,12 +2,23 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"testing"
 )
 
+func TestPathTransformFunc(t *testing.T) {
+	key := "mybestpricture"
+	pathName := CASPathTransformFunc(key)
+	fmt.Println(pathName)
+	exptPathName := "8d28b/f64ba/39cf9/27180/490ed/86827/d71ae/b3526"
+	if pathName != exptPathName {
+		t.Errorf("dfs: expected pathName to be %s, but got %s", exptPathName, pathName)
+	}
+
+}
 func TestStore(t *testing.T) {
 	opts := StoreOpts{
-		PathTransformFunc: DefaultPathTransformFunc,
+		PathTransformFunc: CASPathTransformFunc,
 	}
 	s := NewStore(opts)
 


### PR DESCRIPTION
**Changelog**: **Add function CASPathTransformFunc** 
#5 continue this file
CASPathTransformFunc takes a key string and returns a string representation of a file path based on a SHA1 hash of the key. The path is constructed by splitting the hash into 5-character segments and joining them with forward slashes. This function is used to generate a file path for storing data in a content-addressable storage (CAS) system, where the path is derived from the content of the data being stored.
store_test.go -> for [Test](https://github.com/imanimen/dfs/store_test.go)
```
key := "mybestpricture"
pathName := CASPathTransformFunc(key)
fmt.Println(pathName)
-> 8d28b/f64ba/39cf9/27180/490ed/86827/d71ae/b3526
```