### PR TITLE
hotfix: storing file issue in buffer reader -> The provided fix reads…

### DIFF
--- a/store_test.go
+++ b/store_test.go
@@ -2,14 +2,12 @@ package main
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
 )
 
 func TestPathTransformFunc(t *testing.T) {
 	key := "mybestpricture"
 	pathName := CASPathTransformFunc(key)
-	fmt.Println(pathName)
 	exptPathName := "8d28b/f64ba/39cf9/27180/490ed/86827/d71ae/b3526"
 	if pathName != exptPathName {
 		t.Errorf("dfs: expected pathName to be %s, but got %s", exptPathName, pathName)
@@ -22,7 +20,7 @@ func TestStore(t *testing.T) {
 	}
 	s := NewStore(opts)
 
-	data := bytes.NewReader([]byte("some jpg bytes"))
+	data := bytes.NewReader([]byte("some jpg byte"))
 	if err := s.writeStream("mySpecialPicture", data); err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
… all data first and then calculates the hash, ensuring a valid filename based on the actual content.